### PR TITLE
Add rule to detect makecab staging of LOLBins

### DIFF
--- a/rules/windows/process_creation/win_sysmon_susp_makecab_lolbin_usage.yml
+++ b/rules/windows/process_creation/win_sysmon_susp_makecab_lolbin_usage.yml
@@ -1,0 +1,39 @@
+title: Suspicious Makecab Usage Against Known LOLBins
+id: 14fdd486-8a7d-4772-a0b2-be7335f3c008
+status: experimental
+description: |
+    Detects usage of makecab.exe to compress known LOLBins (regsvr32, rundll32, mshta, certreq).
+    Attackers often use this technique for staging and defense evasion.
+    This rule specifically looks for makecab.exe referencing these binaries in its command line,
+    which is typically uncommon in normal environments.
+references:
+    - https://lolbas-project.github.io
+    - https://attack.mitre.org/techniques/T1560/001
+    - https://car.mitre.org/analytics/CAR-2020-05-003
+author: alexegorov1
+date: 2025-04-04
+tags:
+    - attack.execution
+    - attack.defense-evasion
+    - attack.t1218
+logsource:
+    product: windows
+    category: process_creation
+    service: sysmon
+detection:
+    selection_makecab_lolbins:
+        Image|contains: 'makecab.exe'
+        CommandLine|contains:
+            - 'regsvr32.exe'
+            - 'certreq.exe'
+            - 'rundll32.exe'
+            - 'mshta.exe'
+    condition: selection_makecab_lolbins
+fields:
+    - CommandLine
+    - ParentImage
+    - ParentCommandLine
+    - CurrentDirectory
+falsepositives:
+    - Rare legitimate packaging scenarios involving these tools
+level: medium


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
--> Adds a new Sigma rule for detecting makecab.exe usage to stage known LOLBins (regsvr32.exe, rundll32.exe, mshta.exe, certreq.exe). This behavior was previously uncovered by existing rules. The rule was field-tested with Chainsaw against real-world Sysmon logs and tuned for reliability: zero false positives in clean baselines, strong signal in known attack traces. YAML schema, field names, and detection logic follow current project conventions. Happy to adjust structure or placement based on team feedback.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	Suspicious Makecab Usage Against Known LOLBins
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
